### PR TITLE
Introduces a basic implementation of `liberty list`

### DIFF
--- a/init.go
+++ b/init.go
@@ -10,10 +10,6 @@ import (
 	"strings"
 )
 
-const (
-	libertyFile = "./liberty.json"
-)
-
 // ExecuteInit asks the user a number of questions to setup the project
 // It creates a liberty (JSON) file with these settings (if provided)
 func ExecuteInit(args []string) {

--- a/list.go
+++ b/list.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+// ExecuteList will print the entire tree of dependencies to the console
+func ExecuteList(args []string) {
+	dependencies := trackFolder(rootDir)
+	fmt.Printf("%v", dependencies)
+}
+
+func trackFolder(path string) string {
+	files, err := ioutil.ReadDir(path)
+	fullPath := ""
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if _, err := os.Stat(path + "/" + libertyFile); err == nil {
+		return removeRootPrefix(path) + "\n"
+	}
+
+	for _, file := range files {
+		if file.IsDir() {
+			newPath := path + "/" + file.Name()
+			fullPath += trackFolder(newPath)
+		}
+	}
+
+	return fullPath
+}
+
+// Removes the `rootDir` prefix from the project names
+func removeRootPrefix(path string) string {
+	return path[len(rootDir)+1 : len(path)]
+}

--- a/main.go
+++ b/main.go
@@ -5,9 +5,12 @@ import (
 	"os"
 )
 
-func main() {
-	fmt.Println("Hello, Liberty!")
+const (
+	libertyFile = "liberty.json"
+	rootDir     = "_libs"
+)
 
+func main() {
 	if !SubCommandsExist() {
 		fmt.Println("Insufficient number of subcommands supplied")
 		os.Exit(2)

--- a/subcommands.go
+++ b/subcommands.go
@@ -8,6 +8,7 @@ import (
 const (
 	getCmd  = "get"
 	initCmd = "init"
+	listCmd = "list"
 )
 
 func SubCommandsExist() bool {
@@ -23,6 +24,8 @@ func ParseSubCommands(subCmdArgs []string) {
 		getCommand(subCmdArgs)
 	case initCmd:
 		initCommand(subCmdArgs)
+	case listCmd:
+		listCommand(subCmdArgs)
 	default:
 		fmt.Println("Liberty does not recognise this command")
 		os.Exit(2)
@@ -35,4 +38,8 @@ func getCommand(subCmdArgs []string) string {
 
 func initCommand(subCmdArgs []string) {
 	ExecuteInit(subCmdArgs)
+}
+
+func listCommand(subCmdArgs []string) {
+	ExecuteList(subCmdArgs)
 }


### PR DESCRIPTION
The implementation at the moment traverses the `_libs` directory and prints out the path of any directory that contains a liberty file. If a directory does not eventually contain a liberty file, it will be omitted entirely from the input.

[ ] Tests
[ ] Code Review