### PR TITLE
Package versioning

### DIFF
--- a/set.go
+++ b/set.go
@@ -7,7 +7,7 @@ import (
 	"github.com/liberty-org/cli/utils"
 )
 
-func ExecuteSetver(args []string) {
+func ExecuteSet(args []string) {
 	if len(args) <= 3 {
 		fmt.Println("Insufficient args to liberty setver")
 		os.Exit(2)

--- a/set_test.go
+++ b/set_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/liberty-org/cli/utils"
+	"github.com/libgit2/git2go"
+)
+
+func TestSetGetsCorrectTag(t *testing.T) {
+	repoPath := utils.CloneGitRepo("git://github.com/liberty-org/cli-test.git", "liberty-org/cli-test")
+	args := []string{"liberty", "set", "liberty-org/cli-test", "v0.0.1"}
+
+	ExecuteSet(args)
+
+	repo, _ := git.OpenRepository(repoPath)
+	isDetached, _ := repo.IsHeadDetached()
+
+	if !isDetached {
+		t.FailNow()
+	}
+
+	os.RemoveAll("./_libs")
+}

--- a/setver.go
+++ b/setver.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/liberty-org/cli/utils"
+)
+
+func ExecuteSetver(args []string) {
+	if len(args) <= 3 {
+		fmt.Println("Insufficient args to liberty setver")
+		os.Exit(2)
+	}
+
+	packageName := args[2]
+	packageVersion := args[3]
+	repoPath := utils.MakePathFromPackage(packageName)
+	utils.SetRepoVersion(repoPath, packageVersion)
+}

--- a/subcommands.go
+++ b/subcommands.go
@@ -12,7 +12,7 @@ const (
 	installCmd = "install"
 	removeCmd  = "remove"
 	helpCmd    = "help"
-	setverCmd  = "setver"
+	setCmd     = "set"
 )
 
 func SubCommandsExist() bool {
@@ -36,8 +36,8 @@ func ParseSubCommands(subCmdArgs []string) {
 		installCommand(subCmdArgs)
 	case removeCmd:
 		removeCommand(subCmdArgs)
-	case setverCmd:
-		setverCommand(subCmdArgs)
+	case setCmd:
+		setCommand(subCmdArgs)
 	default:
 		fmt.Println("Liberty does not recognise this command")
 		os.Exit(2)
@@ -68,6 +68,6 @@ func helpCommand(subCmdArgs []string) {
 	ExecuteHelp(subCmdArgs)
 }
 
-func setverCommand(subCmdArgs []string) {
-	ExecuteSetver(subCmdArgs)
+func setCommand(subCmdArgs []string) {
+	ExecuteSet(subCmdArgs)
 }

--- a/subcommands.go
+++ b/subcommands.go
@@ -12,6 +12,7 @@ const (
 	installCmd = "install"
 	removeCmd  = "remove"
 	helpCmd    = "help"
+	setverCmd  = "setver"
 )
 
 func SubCommandsExist() bool {
@@ -35,6 +36,8 @@ func ParseSubCommands(subCmdArgs []string) {
 		installCommand(subCmdArgs)
 	case removeCmd:
 		removeCommand(subCmdArgs)
+	case setverCmd:
+		setverCommand(subCmdArgs)
 	default:
 		fmt.Println("Liberty does not recognise this command")
 		os.Exit(2)
@@ -63,4 +66,8 @@ func removeCommand(subCmdArgs []string) {
 
 func helpCommand(subCmdArgs []string) {
 	ExecuteHelp(subCmdArgs)
+}
+
+func setverCommand(subCmdArgs []string) {
+	ExecuteSetver(subCmdArgs)
 }

--- a/utils/git.go
+++ b/utils/git.go
@@ -75,8 +75,13 @@ func SetRepoVersion(packagePath string, packageVersion string) {
 		os.Exit(1)
 	}
 
-	taggedVersion := tagsPrefix + packageVersion
-	err = repo.SetHead(taggedVersion)
+	ref, err := repo.References.Dwim(packageVersion)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	err = repo.SetHead(ref.Name())
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/utils/git.go
+++ b/utils/git.go
@@ -62,6 +62,11 @@ func CloneGitRepo(gitPath string, dest string) string {
 	return repository
 }
 
+func MakePathFromPackage(packageName string) string {
+	path := LibsDir + packageName
+	return path
+}
+
 func SetRepoVersion(packagePath string, packageVersion string) {
 	repo, err := git.OpenRepository(packagePath)
 	if err != nil {

--- a/utils/git.go
+++ b/utils/git.go
@@ -61,3 +61,17 @@ func CloneGitRepo(gitPath string, dest string) string {
 
 	return repository
 }
+
+func SetRepoVersion(packagePath string, packageVersion string) {
+	repo, err := git.OpenRepository(packagePath)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	err = repo.SetHead(packageVersion)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/utils/git.go
+++ b/utils/git.go
@@ -16,6 +16,7 @@ type Repository struct {
 
 const (
 	LibsDir      = "./_libs/"
+	tagsPrefix   = "tags/"
 	dotGitSuffix = ".git"
 )
 
@@ -74,7 +75,8 @@ func SetRepoVersion(packagePath string, packageVersion string) {
 		os.Exit(1)
 	}
 
-	err = repo.SetHead(packageVersion)
+	taggedVersion := tagsPrefix + packageVersion
+	err = repo.SetHead(taggedVersion)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
With <code>liberty setver vendor/package v1.0.1</code> syntax, you can set a package's version, given a valid git tag.